### PR TITLE
Llmservice incorrect options feature

### DIFF
--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -82,6 +82,22 @@ app.post('/ask', async (req, res) => {
   }
 });
 
+// Generation of incorrect options via llm
+app.post('/generateIncorrectOptions', async (req, res) => {
+  try {
+    // validateFields(req, ['model', 'apiKey', 'correctAnswer']);
+
+    const {model, apiKey, correctAnswer } = req.body;
+    const incorrectOptions = [];
+    var question = "I need to generate incorrect options for a multiple choice question of exactly 4 options. The question is: What country is represented by the flag shown? The correct answer to this question is:" + correctAnswer + ". I need you to generate 3 incorrect options for that question that could be used as distractors. They should be plausible but different from the correct one. Provide them as 3 comma-separated values, nothing more.";
+    const answer = await sendQuestionToLLM(question, apiKey, model);
+    res.json({ answer });
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+
 const server = app.listen(port, () => {
   console.log(`LLM Service listening at http://localhost:${port}`);
 });

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -88,10 +88,10 @@ app.post('/generateIncorrectOptions', async (req, res) => {
     // validateFields(req, ['model', 'apiKey', 'correctAnswer']);
 
     const {model, apiKey, correctAnswer } = req.body;
-    const incorrectOptions = [];
     var question = "I need to generate incorrect options for a multiple choice question of exactly 4 options. The question is: What country is represented by the flag shown? The correct answer to this question is:" + correctAnswer + ". I need you to generate 3 incorrect options for that question that could be used as distractors. They should be plausible but different from the correct one. Provide them as 3 comma-separated values, nothing more.";
     const answer = await sendQuestionToLLM(question, apiKey, model);
-    res.json({ answer });
+    incorrectOptions = answer.split(",");
+    res.json({ incorrectOptions });
   } catch (error) {
     res.status(400).json({ error: error.message });
   }

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -1,5 +1,5 @@
-const axios = require('axios');
-const express = require('express');
+const axios = require("axios");
+const express = require("express");
 
 const app = express();
 const port = 8003;
@@ -10,27 +10,29 @@ app.use(express.json());
 // Define configurations for different LLM APIs
 const llmConfigs = {
   gemini: {
-    url: (apiKey) => `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+    url: (apiKey) =>
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
     transformRequest: (question) => ({
-      contents: [{ parts: [{ text: question }] }]
+      contents: [{ parts: [{ text: question }] }],
     }),
-    transformResponse: (response) => response.data.candidates[0]?.content?.parts[0]?.text
+    transformResponse: (response) =>
+      response.data.candidates[0]?.content?.parts[0]?.text,
   },
   empathy: {
-    url: () => 'https://empathyai.prod.empathy.co/v1/chat/completions',
+    url: () => "https://empathyai.prod.empathy.co/v1/chat/completions",
     transformRequest: (question) => ({
       model: "qwen/Qwen2.5-Coder-7B-Instruct",
       messages: [
         { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: question }
-      ]
+        { role: "user", content: question },
+      ],
     }),
     transformResponse: (response) => response.data.choices[0]?.message?.content,
     headers: (apiKey) => ({
       Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
-    })
-  }
+      "Content-Type": "application/json",
+    }),
+  },
 };
 
 // Function to validate required fields in the request body
@@ -43,7 +45,7 @@ function validateRequiredFields(req, requiredFields) {
 }
 
 // Generic function to send questions to LLM
-async function sendQuestionToLLM(question, apiKey, model = 'gemini') {
+async function sendQuestionToLLM(question, apiKey, model = "gemini") {
   try {
     const config = llmConfigs[model];
     if (!config) {
@@ -54,41 +56,45 @@ async function sendQuestionToLLM(question, apiKey, model = 'gemini') {
     const requestData = config.transformRequest(question);
 
     const headers = {
-      'Content-Type': 'application/json',
-      ...(config.headers ? config.headers(apiKey) : {})
+      "Content-Type": "application/json",
+      ...(config.headers ? config.headers(apiKey) : {}),
     };
 
     const response = await axios.post(url, requestData, { headers });
 
     return config.transformResponse(response);
-
   } catch (error) {
-    console.error(`Error sending question to ${model}:`, error.message || error);
+    console.error(
+      `Error sending question to ${model}:`,
+      error.message || error
+    );
     return null;
   }
 }
 
-app.post('/ask', async (req, res) => {
+app.post("/ask", async (req, res) => {
   try {
     // Check if required fields are present in the request body
-    validateRequiredFields(req, ['question', 'model', 'apiKey']);
+    validateRequiredFields(req, ["question", "model", "apiKey"]);
 
     const { question, model, apiKey } = req.body;
     const answer = await sendQuestionToLLM(question, apiKey, model);
     res.json({ answer });
-
   } catch (error) {
     res.status(400).json({ error: error.message });
   }
 });
 
 // Generation of incorrect options via llm
-app.post('/generateIncorrectOptions', async (req, res) => {
+app.post("/generateIncorrectOptions", async (req, res) => {
   try {
     // validateFields(req, ['model', 'apiKey', 'correctAnswer']);
 
-    const {model, apiKey, correctAnswer } = req.body;
-    var question = "I need to generate incorrect options for a multiple choice question of exactly 4 options. The question is: What country is represented by the flag shown? The correct answer to this question is:" + correctAnswer + ". I need you to generate 3 incorrect options for that question that could be used as distractors. They should be plausible but different from the correct one. Provide them as 3 comma-separated values, nothing more.";
+    const { model, apiKey, correctAnswer } = req.body;
+    var question =
+      "I need to generate incorrect options for a multiple choice question of exactly 4 options. The question is: What country is represented by the flag shown? The correct answer to this question is:" +
+      correctAnswer +
+      ". I need you to generate 3 incorrect options for that question that could be used as distractors. They should be plausible but different from the correct one. Provide them as 3 comma-separated values, nothing more.";
     const answer = await sendQuestionToLLM(question, apiKey, model);
     incorrectOptions = answer.split(",");
     res.json({ incorrectOptions });
@@ -97,11 +103,8 @@ app.post('/generateIncorrectOptions', async (req, res) => {
   }
 });
 
-
 const server = app.listen(port, () => {
   console.log(`LLM Service listening at http://localhost:${port}`);
 });
 
-module.exports = server
-
-
+module.exports = server;

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -88,15 +88,15 @@ app.post("/ask", async (req, res) => {
 // Generation of incorrect options via llm
 app.post("/generateIncorrectOptions", async (req, res) => {
   try {
-    // validateFields(req, ['model', 'apiKey', 'correctAnswer']);
+    validateRequiredFields(req, ['model', 'apiKey', 'correctAnswer']);
 
     const { model, apiKey, correctAnswer } = req.body;
-    var question =
+    let question =
       "I need to generate incorrect options for a multiple choice question of exactly 4 options. The question is: What country is represented by the flag shown? The correct answer to this question is:" +
       correctAnswer +
       ". I need you to generate 3 incorrect options for that question that could be used as distractors. They should be plausible but different from the correct one. Provide them as 3 comma-separated values, nothing more.";
     const answer = await sendQuestionToLLM(question, apiKey, model);
-    incorrectOptions = answer.split(",");
+    let incorrectOptions = answer.split(",");
     res.json({ incorrectOptions });
   } catch (error) {
     res.status(400).json({ error: error.message });

--- a/llmservice/llm-service.js
+++ b/llmservice/llm-service.js
@@ -48,6 +48,7 @@ function validateRequiredFields(req, requiredFields) {
 async function sendQuestionToLLM(question, apiKey, model) {
   const config = llmConfigs[model];
   if (!config) {
+    // This errror should be catched in the endpoints that call this function
     throw new Error(`Model "${model}" is not supported.`);
   }
 

--- a/llmservice/llm-service.test.js
+++ b/llmservice/llm-service.test.js
@@ -9,16 +9,24 @@ afterAll(async () => {
 jest.mock('axios');
 
 describe('LLM Service', () => {
+
+  beforeEach(() => {
   // Mock responses from external services
   axios.post.mockImplementation((url, data) => {
     if (url.startsWith('https://generativelanguage')) {
       return Promise.resolve({ data: { candidates: [{ content: { parts: [{ text: 'llmanswer' }] } }] } });
-    } else if (url.endsWith('https://empathyai')) {
-      return Promise.resolve({ data: { answer: 'llmanswer' } });
+    } else if (url.startsWith('https://empathyai')) {
+      // response.data.choices[0]?.message?.content,
+      return Promise.resolve({ data: { choices: [{message: {content: 'llmanswer'}}]} } );
     }
   });
+  });
 
-  // Test /ask endpoint
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // Test /ask endpoint with gemini
   it('the llm should reply', async () => {
     const response = await request(app)
       .post('/ask')
@@ -28,4 +36,52 @@ describe('LLM Service', () => {
     expect(response.body.answer).toBe('llmanswer');
   });
 
+  // Test /ask endpoint with empathy
+  it('the llm should reply', async () => {
+    const response = await request(app)
+      .post('/ask')
+      .send({ question: 'a question', apiKey: 'apiKey', model: 'empathy' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.answer).toBe('llmanswer');
+});
+});
+
+
+describe('Distractors generation', () => {
+
+  beforeEach(() => {
+    // Mock responses from external services
+  axios.post.mockImplementation((url, data) => {
+    if (url.startsWith('https://generativelanguage')) {
+      return Promise.resolve({ data: { candidates: [{ content: { parts: [{ text: 'India,Nepal,Mongolia' }] } }] } });
+    } else if (url.startsWith('https://empathyai')) {
+      return Promise.resolve({ data: { choices: [{message: {content: 'Gabon,Somalia,Niger'}}]} } );
+    }
+  });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // Test endpoint with empathy
+  it('should generate distractors', async () => {
+    const response = await request(app)
+      .post('/generateIncorrectOptions')
+      .send({ model: 'empathy', apiKey: 'apiKey', correctAnswer: 'Cote D\'Ivoire' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.incorrectOptions).toEqual(['Gabon', 'Somalia', 'Niger']);
+});
+
+// Test endpoint with gemini
+it('should generate distractors', async () => {
+  const response = await request(app)
+    .post('/generateIncorrectOptions')
+    .send({ model: 'gemini', apiKey: 'apiKey', correctAnswer: 'Somalia' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.incorrectOptions).toEqual(['India', 'Nepal', 'Mongolia']);
+});
 });

--- a/llmservice/llm-service.test.js
+++ b/llmservice/llm-service.test.js
@@ -1,6 +1,7 @@
 const request = require("supertest");
 const axios = require("axios");
 const app = require("./llm-service");
+const e = require("express");
 
 afterAll(async () => {
   app.close();
@@ -8,23 +9,27 @@ afterAll(async () => {
 
 jest.mock("axios");
 
+function generateTemplateMocks() {
+  axios.post.mockImplementation((url, data) => {
+    if (url.startsWith("https://generativelanguage")) {
+      return Promise.resolve({
+        data: {
+          candidates: [{ content: { parts: [{ text: "llmanswer" }] } }],
+        },
+      });
+    } else if (url.startsWith("https://empathyai")) {
+      // response.data.choices[0]?.message?.content,
+      return Promise.resolve({
+        data: { choices: [{ message: { content: "llmanswer" } }] },
+      });
+    }
+  });
+}
+
 describe("LLM Service", () => {
   beforeEach(() => {
     // Mock responses from external services
-    axios.post.mockImplementation((url, data) => {
-      if (url.startsWith("https://generativelanguage")) {
-        return Promise.resolve({
-          data: {
-            candidates: [{ content: { parts: [{ text: "llmanswer" }] } }],
-          },
-        });
-      } else if (url.startsWith("https://empathyai")) {
-        // response.data.choices[0]?.message?.content,
-        return Promise.resolve({
-          data: { choices: [{ message: { content: "llmanswer" } }] },
-        });
-      }
-    });
+    generateTemplateMocks();
   });
 
   afterEach(() => {
@@ -78,13 +83,11 @@ describe("Distractors generation", () => {
 
   // Test endpoint with empathy
   it("should generate distractors", async () => {
-    const response = await request(app)
-      .post("/generateIncorrectOptions")
-      .send({
-        model: "empathy",
-        apiKey: "apiKey",
-        correctAnswer: "Cote D'Ivoire",
-      });
+    const response = await request(app).post("/generateIncorrectOptions").send({
+      model: "empathy",
+      apiKey: "apiKey",
+      correctAnswer: "Cote D'Ivoire",
+    });
 
     expect(response.statusCode).toBe(200);
     expect(response.body.incorrectOptions).toEqual([
@@ -106,5 +109,39 @@ describe("Distractors generation", () => {
       "Nepal",
       "Mongolia",
     ]);
+  });
+});
+
+describe("Error handling", () => {
+  beforeEach(() => {
+    generateTemplateMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should fail if the model is not supported", async () => {
+    const response = await request(app)
+      .post("/ask")
+      .send({ question: "a question", apiKey: "apiKey", model: "openai" });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should fail if the required fields are missing when asking a question", async () => {
+    const response = await request(app)
+      .post("/ask")
+      .send({ question: "a question", apiKey: "apiKey" });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should fail if the required fields are missing when generating the distractors", async () => {
+    const response = await request(app)
+      .post("/generateIncorrectOptions")
+      .send({ question: "a question", model: "gemini" });
+
+    expect(response.statusCode).toBe(400);
   });
 });

--- a/llmservice/llm-service.test.js
+++ b/llmservice/llm-service.test.js
@@ -1,25 +1,30 @@
-const request = require('supertest');
-const axios = require('axios');
-const app = require('./llm-service'); 
+const request = require("supertest");
+const axios = require("axios");
+const app = require("./llm-service");
 
 afterAll(async () => {
-    app.close();
-  });
+  app.close();
+});
 
-jest.mock('axios');
+jest.mock("axios");
 
-describe('LLM Service', () => {
-
+describe("LLM Service", () => {
   beforeEach(() => {
-  // Mock responses from external services
-  axios.post.mockImplementation((url, data) => {
-    if (url.startsWith('https://generativelanguage')) {
-      return Promise.resolve({ data: { candidates: [{ content: { parts: [{ text: 'llmanswer' }] } }] } });
-    } else if (url.startsWith('https://empathyai')) {
-      // response.data.choices[0]?.message?.content,
-      return Promise.resolve({ data: { choices: [{message: {content: 'llmanswer'}}]} } );
-    }
-  });
+    // Mock responses from external services
+    axios.post.mockImplementation((url, data) => {
+      if (url.startsWith("https://generativelanguage")) {
+        return Promise.resolve({
+          data: {
+            candidates: [{ content: { parts: [{ text: "llmanswer" }] } }],
+          },
+        });
+      } else if (url.startsWith("https://empathyai")) {
+        // response.data.choices[0]?.message?.content,
+        return Promise.resolve({
+          data: { choices: [{ message: { content: "llmanswer" } }] },
+        });
+      }
+    });
   });
 
   afterEach(() => {
@@ -27,38 +32,44 @@ describe('LLM Service', () => {
   });
 
   // Test /ask endpoint with gemini
-  it('the llm should reply', async () => {
+  it("the llm should reply", async () => {
     const response = await request(app)
-      .post('/ask')
-      .send({ question: 'a question', apiKey: 'apiKey', model: 'gemini' });
+      .post("/ask")
+      .send({ question: "a question", apiKey: "apiKey", model: "gemini" });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.answer).toBe('llmanswer');
+    expect(response.body.answer).toBe("llmanswer");
   });
 
   // Test /ask endpoint with empathy
-  it('the llm should reply', async () => {
+  it("the llm should reply", async () => {
     const response = await request(app)
-      .post('/ask')
-      .send({ question: 'a question', apiKey: 'apiKey', model: 'empathy' });
+      .post("/ask")
+      .send({ question: "a question", apiKey: "apiKey", model: "empathy" });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.answer).toBe('llmanswer');
+    expect(response.body.answer).toBe("llmanswer");
+  });
 });
-});
 
-
-describe('Distractors generation', () => {
-
+describe("Distractors generation", () => {
   beforeEach(() => {
     // Mock responses from external services
-  axios.post.mockImplementation((url, data) => {
-    if (url.startsWith('https://generativelanguage')) {
-      return Promise.resolve({ data: { candidates: [{ content: { parts: [{ text: 'India,Nepal,Mongolia' }] } }] } });
-    } else if (url.startsWith('https://empathyai')) {
-      return Promise.resolve({ data: { choices: [{message: {content: 'Gabon,Somalia,Niger'}}]} } );
-    }
-  });
+    axios.post.mockImplementation((url, data) => {
+      if (url.startsWith("https://generativelanguage")) {
+        return Promise.resolve({
+          data: {
+            candidates: [
+              { content: { parts: [{ text: "India,Nepal,Mongolia" }] } },
+            ],
+          },
+        });
+      } else if (url.startsWith("https://empathyai")) {
+        return Promise.resolve({
+          data: { choices: [{ message: { content: "Gabon,Somalia,Niger" } }] },
+        });
+      }
+    });
   });
 
   afterEach(() => {
@@ -66,22 +77,34 @@ describe('Distractors generation', () => {
   });
 
   // Test endpoint with empathy
-  it('should generate distractors', async () => {
+  it("should generate distractors", async () => {
     const response = await request(app)
-      .post('/generateIncorrectOptions')
-      .send({ model: 'empathy', apiKey: 'apiKey', correctAnswer: 'Cote D\'Ivoire' });
+      .post("/generateIncorrectOptions")
+      .send({
+        model: "empathy",
+        apiKey: "apiKey",
+        correctAnswer: "Cote D'Ivoire",
+      });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.incorrectOptions).toEqual(['Gabon', 'Somalia', 'Niger']);
-});
+    expect(response.body.incorrectOptions).toEqual([
+      "Gabon",
+      "Somalia",
+      "Niger",
+    ]);
+  });
 
-// Test endpoint with gemini
-it('should generate distractors', async () => {
-  const response = await request(app)
-    .post('/generateIncorrectOptions')
-    .send({ model: 'gemini', apiKey: 'apiKey', correctAnswer: 'Somalia' });
+  // Test endpoint with gemini
+  it("should generate distractors", async () => {
+    const response = await request(app)
+      .post("/generateIncorrectOptions")
+      .send({ model: "gemini", apiKey: "apiKey", correctAnswer: "Somalia" });
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.incorrectOptions).toEqual(['India', 'Nepal', 'Mongolia']);
-});
+    expect(response.body.incorrectOptions).toEqual([
+      "India",
+      "Nepal",
+      "Mongolia",
+    ]);
+  });
 });

--- a/llmservice/llm-service.test.js
+++ b/llmservice/llm-service.test.js
@@ -121,9 +121,17 @@ describe("Error handling", () => {
     jest.resetAllMocks();
   });
 
-  it("should fail if the model is not supported", async () => {
+  it("should fail if the model is not supported when asking a question", async () => {
     const response = await request(app)
       .post("/ask")
+      .send({ question: "a question", apiKey: "apiKey", model: "openai" });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should fail if the model is not supported when generating the distractors", async () => {
+    const response = await request(app)
+      .post("/generateIncorrectOptions")
       .send({ question: "a question", apiKey: "apiKey", model: "openai" });
 
     expect(response.statusCode).toBe(400);
@@ -140,7 +148,7 @@ describe("Error handling", () => {
   it("should fail if the required fields are missing when generating the distractors", async () => {
     const response = await request(app)
       .post("/generateIncorrectOptions")
-      .send({ question: "a question", model: "gemini" });
+      .send({ correctAnswer: "an answer", model: "gemini" });
 
     expect(response.statusCode).toBe(400);
   });


### PR DESCRIPTION
Added functionality for the LLM service where we will delegate the creation of the distractors. This implementation will return an array containing 3 incorrect answers provided the correct answer. So for example, for the request:

`http://localhost:8003/generateIncorrectOptions`
And within the body of the request we have:
```
{
    "model": "empathy",
    "apiKey": "apiKey", // To be replaced by our API key
    "correctAnswer": "Cote D'Ivoire"
}
```
An example response is:
```
{
    "incorrectOptions": [
        [
            "Nigeria",
            "Togo",
            "Mali"
        ]
    ]
}
```

Note that the endpoint is likely to change due to another issue where they are depending on this implementation, see on:

-  #41