### PR TITLE
FIX: Incorrect answers are finally generated and store properly in DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
     build: ./questionservice
     depends_on:
       - mongodb
+      - llmservice
     ports:
       - "8004:8004"
     networks:

--- a/questionservice/question-service.js
+++ b/questionservice/question-service.js
@@ -45,7 +45,7 @@ async function fetchFlagData() {
 
             try {
                 // Call the LLM service to generate incorrect answers
-                const llmResponse = await axios.post('http://localhost:8003/generateIncorrectOptions', {
+                const llmResponse = await axios.post('http://llmservice:8003/generateIncorrectOptions', {
                     model: "empathy",
                     correctAnswer: correctAnswer
                 });

--- a/questionservice/question-service.js
+++ b/questionservice/question-service.js
@@ -44,7 +44,8 @@ async function fetchFlagData() {
             const imageUrl = entry.flag.value;
 
             try {
-                // Call the LLM service to generate incorrect answers
+                // Call the LLM service to generate incorrect answers, if you are running the application with npm start, then
+                // use this link: 'http://localhost:8003/generateIncorrectOptions'
                 const llmResponse = await axios.post('http://llmservice:8003/generateIncorrectOptions', {
                     model: "empathy",
                     correctAnswer: correctAnswer


### PR DESCRIPTION
Fix issue #71.
Several things (but small) to solve the problem:
- In [docker-compose.yml](https://github.com/Arquisoft/wichat_en2a/blob/master/docker-compose.yml) we forgot to put that questionservice depends on llmservice.
- In [question-service.js](https://github.com/Arquisoft/wichat_en2a/blob/master/questionservice/question-service.js) the url for llmservice was not right, we have to substitude localhost:8003 by llmservice:8003 because it is the name it has in docker.
- Taking a look to our mongoDB, as i have been deploying it since the very beggining, there was like +1000 questions and just the last 30 generated questions were the ones with incorrect answers (the ones generated after the two previous changes). So I delete all the questions, re-deploy the application and now they are right.