### PR TITLE
Added prometheus and grafana to production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,10 +228,52 @@ jobs:
         workdir: gatewayservice
         platforms: linux/amd64,linux/arm64
 
+  docker-push-prometheus:
+    name: Push prometheus Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs: [e2e-tests]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@v5
+      with:
+        name: arquisoft/wichat_en2a/prometheus
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
+        workdir: gatewayservice/monitoring/prometheus
+        platforms: linux/amd64,linux/arm64
+  
+  docker-push-grafana:
+    name: Push grafana Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs: [e2e-tests]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@v5
+      with:
+        name: arquisoft/wichat_en2a/grafana
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
+        workdir: gatewayservice/monitoring/grafana
+        platforms: linux/amd64,linux/arm64
+
   deploy:
     name: Deploy over SSH
     runs-on: ubuntu-latest
-    needs: [docker-push-userservice,docker-push-authservice,docker-push-llmservice,docker-push-gameservice,docker-push-questionservice,docker-push-gatewayservice,docker-push-webapp]
+    needs: [docker-push-userservice,docker-push-authservice,docker-push-llmservice,docker-push-gameservice,docker-push-questionservice,docker-push-gatewayservice,docker-push-webapp,docker-push-prometheus,docker-push-grafana]
     steps:
     - name: Deploy over SSH
       uses: fifsky/ssh-action@master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
   prometheus:
     image: prom/prometheus
     container_name: prometheus-wichat_en2a
-    profiles: ["dev"]
+    profiles: ["dev", "prod"]
     networks:
       - mynetwork
     volumes:
@@ -161,7 +161,7 @@ services:
   grafana:
     image: grafana/grafana
     container_name: grafana-wichat_en2a
-    profiles: ["dev"]
+    profiles: ["dev", "prod"]
     networks:
       - mynetwork
     volumes:


### PR DESCRIPTION
I have modified the docker-compose and actions for deploying. We should assure that both Grafana and Prometheus ought to be used in production. Otherwise, we should just discard this changes.